### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- configure the GitHub Pages action before uploading the static site artifact to avoid deployment failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e294d0c70c8331ac63060a429eca18