### PR TITLE
Disable Jekyll during Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Disable Jekyll processing
+        run: touch dist/.nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- ensure the built site includes a .nojekyll marker before uploading the Pages artifact so the static bundle is served instead of the repository README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e294d0c70c8331ac63060a429eca18