### PR TITLE
Improve lab visuals and confusion matrix layouts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,11 +50,12 @@ function App() {
               return (
                 <Button
                   key={tab.id}
-                  variant={isActive ? 'default' : 'outline'}
+                  variant="ghost"
                   className={
-                    isActive
-                      ? 'bg-white/90 text-slate-900 hover:bg-white'
-                      : 'border-white/50 text-white hover:bg-white/10 hover:text-white'
+                    'border backdrop-blur transition-all ' +
+                    (isActive
+                      ? 'border-white/80 bg-white text-slate-900 shadow-lg hover:bg-white/90 hover:text-slate-900'
+                      : 'border-white/40 bg-white/10 text-white/90 hover:bg-white/20 hover:text-white')
                   }
                   onClick={() => setActiveTab(tab.id)}
                 >

--- a/frontend/src/components/ConfusionMatrixTable.tsx
+++ b/frontend/src/components/ConfusionMatrixTable.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+
+interface ConfusionMatrixTableProps<TClass extends string> {
+  matrix: Array<Array<{ actual: TClass; predicted: TClass; value: number }>>;
+  classOrder: TClass[];
+  getClassLabel: (value: TClass) => string;
+  getClassColor: (value: TClass) => string;
+}
+
+export function ConfusionMatrixTable<TClass extends string>({
+  matrix,
+  classOrder,
+  getClassLabel,
+  getClassColor,
+}: ConfusionMatrixTableProps<TClass>) {
+  const { maxValue, totals, rowMap } = useMemo(() => {
+    let max = 0;
+    const totalPerActual = {} as Record<TClass, number>;
+    const matrixMap = {} as Record<TClass, Record<TClass, number>>;
+
+    classOrder.forEach((actual) => {
+      totalPerActual[actual] = 0;
+      matrixMap[actual] = {} as Record<TClass, number>;
+      classOrder.forEach((predicted) => {
+        matrixMap[actual][predicted] = 0;
+      });
+    });
+
+    matrix.forEach((row) => {
+      row.forEach((cell) => {
+        if (cell.value > max) {
+          max = cell.value;
+        }
+        totalPerActual[cell.actual] += cell.value;
+        matrixMap[cell.actual][cell.predicted] = cell.value;
+      });
+    });
+
+    return { maxValue: Math.max(max, 1), totals: totalPerActual, rowMap: matrixMap };
+  }, [classOrder, matrix]);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-separate border-spacing-0 text-sm">
+        <thead>
+          <tr>
+            <th className="bg-white px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Настоящий \ Предсказанный
+            </th>
+            {classOrder.map((cls) => (
+              <th
+                key={cls}
+                className="bg-muted/40 px-4 py-3 text-center text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+              >
+                {getClassLabel(cls)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {classOrder.map((actual) => (
+            <tr key={actual}>
+              <th className="bg-muted/30 px-4 py-3 text-left font-semibold text-muted-foreground">
+                {getClassLabel(actual)}
+                <span className="ml-2 text-xs font-normal text-muted-foreground/70">
+                  {`${totals[actual] ?? 0} шт.`}
+                </span>
+              </th>
+              {classOrder.map((predicted) => {
+                const value = rowMap[actual]?.[predicted] ?? 0;
+                const intensity = value / maxValue;
+                const background = mixColor(getClassColor(predicted), 0.18 + intensity * 0.55);
+                const textColor = intensity > 0.55 ? '#0f172a' : '#0f172a';
+                return (
+                  <td key={predicted} className="px-4 py-3 text-center" style={{ backgroundColor: background, color: textColor }}>
+                    <div className="flex flex-col items-center gap-1">
+                      <span className="text-base font-semibold">{value}</span>
+                      <span className="text-[11px] uppercase tracking-wide text-muted-foreground/70">
+                        {getClassLabel(predicted)}
+                      </span>
+                    </div>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function mixColor(hex: string, alpha: number) {
+  const { r, g, b } = hexToRgb(hex);
+  const clampedAlpha = Math.min(Math.max(alpha, 0.1), 0.85);
+  return `rgba(${r}, ${g}, ${b}, ${clampedAlpha})`;
+}
+
+function hexToRgb(hex: string) {
+  let value = hex.replace('#', '');
+  if (value.length === 3) {
+    value = value
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  const numeric = Number.parseInt(value, 16);
+  const r = (numeric >> 16) & 255;
+  const g = (numeric >> 8) & 255;
+  const b = numeric & 255;
+  return { r, g, b };
+}

--- a/frontend/src/components/DecisionBoundaryCanvas.tsx
+++ b/frontend/src/components/DecisionBoundaryCanvas.tsx
@@ -1,15 +1,27 @@
 import { useMemo } from 'react';
-import { DecisionGridData, IrisSample, Species } from '../types';
-import { getClassColor } from '../lib/utils';
+import type { DecisionGridData } from '../types';
 
-interface DecisionBoundaryCanvasProps {
-  grid: DecisionGridData;
-  points: IrisSample[];
+interface DecisionBoundaryCanvasProps<TPoint extends { pcaX: number; pcaY: number }, TClass extends string> {
+  grid: DecisionGridData<TClass>;
+  points: TPoint[];
+  getPointClass: (point: TPoint) => TClass;
+  getClassColor: (value: TClass) => string;
+  title?: string;
+  description?: string;
 }
 
-const speciesOrder: Species[] = ['Setosa', 'Versicolor', 'Virginica'];
+const defaultTitle = 'Как сеть рисует границы ✍️';
+const defaultDescription =
+  'Цветной фон — решение сети, точки — настоящие образцы из теста. Если точка в «чужой» зоне, модель ошиблась.';
 
-export function DecisionBoundaryCanvas({ grid, points }: DecisionBoundaryCanvasProps) {
+export function DecisionBoundaryCanvas<TPoint extends { pcaX: number; pcaY: number }, TClass extends string>({
+  grid,
+  points,
+  getPointClass,
+  getClassColor,
+  title = defaultTitle,
+  description = defaultDescription,
+}: DecisionBoundaryCanvasProps<TPoint, TClass>) {
   const canvasData = useMemo(() => {
     if (!grid.grid.length || !grid.grid[0]?.length) {
       return null;
@@ -17,7 +29,7 @@ export function DecisionBoundaryCanvas({ grid, points }: DecisionBoundaryCanvasP
     const width = 600;
     const height = 400;
     const cells: Array<{ x: number; y: number; color: string }> = [];
-    const { grid: matrix, minX, maxX, minY, maxY } = grid;
+    const { grid: matrix, minX, maxX, minY, maxY, classOrder } = grid;
     const stepX = width / matrix.length;
     const stepY = height / matrix[0].length;
     matrix.forEach((row, ix) => {
@@ -25,17 +37,17 @@ export function DecisionBoundaryCanvas({ grid, points }: DecisionBoundaryCanvasP
         cells.push({
           x: ix * stepX,
           y: height - (iy + 1) * stepY,
-          color: getClassColor(speciesOrder[value]),
+          color: getClassColor(classOrder[value]),
         });
       });
     });
     const scaledPoints = points.map((point) => ({
       x: ((point.pcaX - minX) / (maxX - minX)) * width,
       y: height - ((point.pcaY - minY) / (maxY - minY)) * height,
-      species: point.species,
+      value: getPointClass(point),
     }));
     return { width, height, cells, scaledPoints, stepX, stepY };
-  }, [grid, points]);
+  }, [grid, points, getPointClass, getClassColor]);
 
   if (!canvasData) {
     return null;
@@ -44,10 +56,8 @@ export function DecisionBoundaryCanvas({ grid, points }: DecisionBoundaryCanvasP
   return (
     <div className="card flex flex-col gap-4">
       <div className="space-y-2">
-        <h3 className="text-2xl font-semibold text-foreground">Как сеть рисует границы ✍️</h3>
-        <p className="text-sm text-muted-foreground">
-          Цветной фон — решение сети, точки — настоящие цветы из теста. Если точка в «чужой» зоне, сеть ошиблась.
-        </p>
+        <h3 className="text-2xl font-semibold text-foreground">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
       </div>
       <div className="overflow-hidden rounded-2xl border border-border bg-white shadow">
         <svg viewBox={`0 0 ${canvasData.width} ${canvasData.height}`} className="w-full">
@@ -55,7 +65,15 @@ export function DecisionBoundaryCanvas({ grid, points }: DecisionBoundaryCanvasP
             <rect key={index} x={cell.x} y={cell.y} width={canvasData.stepX} height={canvasData.stepY} fill={cell.color} opacity={0.5} />
           ))}
           {canvasData.scaledPoints.map((point, index) => (
-            <circle key={index} cx={point.x} cy={point.y} r={6} fill={getClassColor(point.species)} stroke="#0f172a" strokeWidth={1.5} />
+            <circle
+              key={index}
+              cx={point.x}
+              cy={point.y}
+              r={6}
+              fill={getClassColor(point.value)}
+              stroke="#0f172a"
+              strokeWidth={1.5}
+            />
           ))}
         </svg>
       </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -68,10 +68,11 @@ export interface TrainingSummary {
   featureStats: FeatureStats | null;
 }
 
-export interface DecisionGridData {
+export interface DecisionGridData<TClass extends string = string> {
   grid: number[][];
   minX: number;
   maxX: number;
   minY: number;
   maxY: number;
+  classOrder: TClass[];
 }


### PR DESCRIPTION
## Summary
- restyle the difficulty tabs so the active state has readable contrast
- replace the confusion-matrix scatter plot with a compact table component shared by both labs
- add a decision-boundary plot and feature stats to the advanced mission using interpolated PCA coordinates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e8a2014c64832791ff4729a09c8754